### PR TITLE
Add emotion detection to API speech synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This a Speech to Speech Translation Application which translates any-language to
 
 ## Introduction
 
-This project demonstrates a real-time speech-to-speech translation system that supports 99 languages using the [Whisper model](https://huggingface.co/openai/whisper-large-v3). The system captures audio input, translates the speech, and synthesizes the translated speech in real-time. The API-based version now includes **voice cloning** so the translated output uses the speaker's own voice.
+This project demonstrates a real-time speech-to-speech translation system that supports 99 languages using the [Whisper model](https://huggingface.co/openai/whisper-large-v3). The system captures audio input, translates the speech, and synthesizes the translated speech in real-time. The API-based version now includes **voice cloning** so the translated output uses the speaker's own voice. It also detects the speaker's **emotion** and applies that tone to the synthesized speech.
 
 If you don't have the required computing power to run the models locally, you can use the OpenAI API for speech-to-text and text-to-speech services. The project supports both configurations: using pre-trained models directly and using OpenAI API.
 
@@ -64,10 +64,8 @@ We welcome contributions from the open-source community to enhance the speech-to
     - [OpenVoiceV2](https://huggingface.co/myshell-ai/OpenVoiceV2)
     - [PSST-Fairseq-Voice-Clone](https://huggingface.co/birgermoell/psst-fairseq-voice-clone)
 
-2. **Emotion Detection**: Add emotion detection to identify the speaker's emotion. Reference model:
+2. **Emotion Detection**: The API version now detects the speaker's emotion and applies it during speech synthesis. Reference model:
     - [wav2vec2-lg-xlsr-en-speech-emotion-recognition](https://huggingface.co/ehcalabres/wav2vec2-lg-xlsr-en-speech-emotion-recognition)
-
-3. **Output Speech with Emotion**: Enhance the system to output synthesized speech with detected emotions.
 
 ## Demo
 

--- a/Speech_to_Speech_API/emotion_detection.py
+++ b/Speech_to_Speech_API/emotion_detection.py
@@ -1,0 +1,19 @@
+import torch
+from transformers import pipeline
+
+# Load the emotion classification pipeline once when the module is imported
+_DEVICE = 0 if torch.cuda.is_available() else -1
+_emotion_classifier = pipeline(
+    "audio-classification",
+    model="ehcalabres/wav2vec2-lg-xlsr-en-speech-emotion-recognition",
+    device=_DEVICE,
+)
+
+
+def detect_emotion(audio_path: str) -> str:
+    """Return the top emotion label for the given audio file."""
+    results = _emotion_classifier(audio_path)
+    if not results:
+        return "neutral"
+    top = max(results, key=lambda r: r["score"])
+    return top["label"]

--- a/Speech_to_Speech_API/requirements.txt
+++ b/Speech_to_Speech_API/requirements.txt
@@ -6,3 +6,5 @@ soundfile
 python-dotenv
 torch
 TTS
+transformers
+torchaudio

--- a/Speech_to_Speech_API/translate_and_synthesize.py
+++ b/Speech_to_Speech_API/translate_and_synthesize.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 from utils import audio_queue, calculate_rms, play_audio
 from audio_capture import RATE
 from voice_clone import load_voice_clone_model, synthesize_with_clone
+from emotion_detection import detect_emotion
 
 speaker_sample = os.getenv("SPEAKER_WAV", "speaker.wav")
 tts_model = load_voice_clone_model()
@@ -31,17 +32,26 @@ def translate_and_synthesize():
 
         with open(audio_file_path, "rb") as audio_file:
             translation = openai.audio.translations.create(
-                model="whisper-1", 
-                file=audio_file
+                model="whisper-1",
+                file=audio_file,
             )
             translated_text = translation.text
             print("Translated Text:", translated_text)
+
+            emotion = detect_emotion(audio_file_path)
+            print("Detected Emotion:", emotion)
 
             speech_file_path = "speech_output.wav"
             prev_mod_time = os.path.getmtime(speech_file_path) if os.path.exists(speech_file_path) else 0
 
             try:
-                synthesize_with_clone(tts_model, translated_text, speaker_sample, file_path=speech_file_path)
+                synthesize_with_clone(
+                    tts_model,
+                    translated_text,
+                    speaker_sample,
+                    emotion=emotion,
+                    file_path=speech_file_path,
+                )
 
                 new_mod_time = os.path.getmtime(speech_file_path)
                 if new_mod_time > prev_mod_time:

--- a/Speech_to_Speech_API/voice_clone.py
+++ b/Speech_to_Speech_API/voice_clone.py
@@ -36,6 +36,28 @@ def load_voice_clone_model():
     return tts
 
 
-def synthesize_with_clone(tts, text, speaker_wav, language="en", file_path="speech_output.wav"):
-    """Synthesize speech using the cloned voice."""
-    tts.tts_to_file(text=text, speaker_wav=speaker_wav, language=language, file_path=file_path)
+EMOTION_PRESETS = {
+    "happy": "happy",
+    "sad": "sad",
+    "angry": "angry",
+    "surprised": "surprised",
+}
+
+
+def synthesize_with_clone(
+    tts,
+    text,
+    speaker_wav,
+    language="en",
+    emotion="neutral",
+    file_path="speech_output.wav",
+):
+    """Synthesize speech using the cloned voice with optional emotion."""
+    preset = EMOTION_PRESETS.get(emotion.lower(), "neutral")
+    tts.tts_to_file(
+        text=text,
+        speaker_wav=speaker_wav,
+        language=language,
+        emotion=preset,
+        file_path=file_path,
+    )


### PR DESCRIPTION
## Summary
- add `emotion_detection.py` module with wav2vec2 model
- support emotion parameter in `synthesize_with_clone`
- detect speaker emotion during translation and apply it in synthesis
- update API requirements for transformers/torchaudio
- document emotion-aware synthesis in README

## Testing
- `python -m py_compile Speech_to_Speech_API/*.py`
